### PR TITLE
Add HTML report for performance tests

### DIFF
--- a/.github/workflows/cf-graphdb-api.yml
+++ b/.github/workflows/cf-graphdb-api.yml
@@ -97,6 +97,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: performance-test-results
-          path: performance/api/*.log
+          path: |
+            performance/api/*.log
+            performance/api/*.html
           retention-days: 7
           if-no-files-found: ignore

--- a/performance/api/load.py
+++ b/performance/api/load.py
@@ -10,6 +10,7 @@ import random
 import statistics
 import datetime
 from collections import defaultdict
+from report_utils import generate_html_report
 
 # === Config ===
 TOTAL_NODES = 100
@@ -591,13 +592,20 @@ async def run_load_test():
     latency_report = generate_latency_report()
     print(latency_report)
 
-    # Save the report to a file
+    # Save text and HTML reports
     try:
         timestamp = metrics["test_end_time"].strftime("%Y%m%d_%H%M%S")
-        filename = f"load_test_latency_{timestamp}.log"
-        with open(filename, "w") as f:
+        text_filename = f"load_test_latency_{timestamp}.log"
+        with open(text_filename, "w") as f:
             f.write(latency_report)
-        print(f"\nLatency report saved to {filename}")
+        print(f"\nLatency report saved to {text_filename}")
+
+        percentiles = calculate_latency_percentiles()
+        html_content = generate_html_report(metrics, percentiles)
+        html_filename = f"load_test_latency_{timestamp}.html"
+        with open(html_filename, "w") as f:
+            f.write(html_content)
+        print(f"HTML report saved to {html_filename}")
     except Exception as e:
         print(f"\nError saving latency report: {str(e)}")
 

--- a/performance/api/load.py
+++ b/performance/api/load.py
@@ -10,7 +10,11 @@ import random
 import statistics
 import datetime
 from collections import defaultdict
-from report_utils import generate_html_report
+from report_utils import (
+    generate_html_report,
+    calculate_latency_percentiles,
+    generate_latency_report,
+)
 
 # === Config ===
 TOTAL_NODES = 100
@@ -336,147 +340,6 @@ async def setup_environment():
         f"Environment setup complete with {len(setup_nodes)} requests in {metrics['operation_phase_times']['setup']:.2f}ms")
 
 
-# === Calculate Percentiles ===
-def calculate_latency_percentiles():
-    all_response_times = []
-
-    # Collect all response times for overall percentile calculations
-    for key, data in metrics["endpoints"].items():
-        all_response_times.extend(data["response_times"])
-
-    if not all_response_times:
-        return {}
-
-    # Sort times for percentile calculations
-    all_response_times.sort()
-    total_count = len(all_response_times)
-
-    # Calculate percentiles
-    percentiles = {
-        "median": statistics.median(all_response_times) if all_response_times else 0,
-        "p90": all_response_times[int(total_count * 0.9)] if total_count > 10 else all_response_times[
-            -1] if all_response_times else 0,
-        "p95": all_response_times[int(total_count * 0.95)] if total_count > 20 else all_response_times[
-            -1] if all_response_times else 0,
-        "p99": all_response_times[int(total_count * 0.99)] if total_count > 100 else all_response_times[
-            -1] if all_response_times else 0
-    }
-
-    # Calculate per-endpoint percentiles
-    endpoint_percentiles = {}
-    for key, data in metrics["endpoints"].items():
-        times = data["response_times"]
-        if times:
-            times.sort()
-            count = len(times)
-            endpoint_percentiles[key] = {
-                "median": statistics.median(times),
-                "p90": times[int(count * 0.9)] if count > 10 else times[-1],
-                "p95": times[int(count * 0.95)] if count > 20 else times[-1],
-                "p99": times[int(count * 0.99)] if count > 100 else times[-1]
-            }
-
-    return {
-        "overall": percentiles,
-        "endpoints": endpoint_percentiles
-    }
-
-
-# === Generate Latency Report ===
-def generate_latency_report():
-    # Calculate percentiles
-    percentiles = calculate_latency_percentiles()
-
-    # Format the report
-    total_requests = metrics["success_count"] + metrics["failure_count"]
-    report = "\n" + "=" * 80 + "\n"
-    report += "                       DETAILED LATENCY METRICS\n"
-    report += "=" * 80 + "\n\n"
-
-    # Test summary
-    report += "TEST SUMMARY:\n"
-    report += f"  Start time: {metrics['test_start_time'].isoformat() if metrics['test_start_time'] else 'N/A'}\n"
-    report += f"  End time: {metrics['test_end_time'].isoformat() if metrics['test_end_time'] else 'N/A'}\n"
-    report += f"  Duration: {metrics['test_duration_seconds']:.2f} seconds\n"
-    report += f"  Total requests: {total_requests}\n"
-    report += f"  Success rate: {metrics['success_count']}/{total_requests} "
-    report += f"({(metrics['success_count'] / total_requests * 100):.2f}%)\n" if total_requests > 0 else "(0.00%)\n"
-    report += f"  Requests per second: {total_requests / metrics['test_duration_seconds']:.2f}\n" if metrics[
-                                                                                                         'test_duration_seconds'] > 0 else "  Requests per second: 0.00\n"
-    report += "\n"
-
-    # Phase timing
-    report += "PHASE TIMING:\n"
-    for phase, duration in metrics["operation_phase_times"].items():
-        report += f"  {phase.replace('_', ' ').title()}: {duration:.2f}ms\n"
-    report += "\n"
-
-    # Latency distribution
-    report += "LATENCY DISTRIBUTION:\n"
-    total_latency_count = sum(metrics["latency_distribution"].values())
-    for range_name, count in metrics["latency_distribution"].items():
-        percentage = (count / total_latency_count * 100) if total_latency_count > 0 else 0
-        report += f"  {range_name}: {count} requests ({percentage:.2f}%)\n"
-    report += "\n"
-
-    # Overall percentiles
-    if "overall" in percentiles:
-        report += "OVERALL LATENCY PERCENTILES:\n"
-        report += f"  Median (P50): {percentiles['overall']['median']:.2f}ms\n"
-        report += f"  P90: {percentiles['overall']['p90']:.2f}ms\n"
-        report += f"  P95: {percentiles['overall']['p95']:.2f}ms\n"
-        report += f"  P99: {percentiles['overall']['p99']:.2f}ms\n"
-        report += "\n"
-
-    # Top 5 slowest endpoints
-    endpoint_avg_times = []
-    for key, data in metrics["endpoints"].items():
-        if data["count"] > 0:
-            avg_time = data["total_time"] / data["count"]
-            endpoint_avg_times.append((key, avg_time, data))
-
-    if endpoint_avg_times:
-        endpoint_avg_times.sort(key=lambda x: x[1], reverse=True)
-        top_5_slowest = endpoint_avg_times[:5]
-
-        report += "TOP 5 SLOWEST ENDPOINTS:\n"
-        for key, avg_time, data in top_5_slowest:
-            report += f"  {key}:\n"
-            report += f"    Count: {data['count']}\n"
-            report += f"    Avg time: {avg_time:.2f}ms\n"
-            report += f"    Min time: {data['min']:.2f}ms\n"
-            report += f"    Max time: {data['max']:.2f}ms\n"
-
-            # Add percentiles if available
-            if "endpoints" in percentiles and key in percentiles["endpoints"]:
-                ep_percentiles = percentiles["endpoints"][key]
-                report += f"    Median (P50): {ep_percentiles['median']:.2f}ms\n"
-                report += f"    P90: {ep_percentiles['p90']:.2f}ms\n"
-                report += f"    P95: {ep_percentiles['p95']:.2f}ms\n"
-                report += f"    P99: {ep_percentiles['p99']:.2f}ms\n"
-
-            report += "\n"
-
-    # Status code distribution
-    report += "STATUS CODE DISTRIBUTION:\n"
-    for code, count in sorted(metrics["status_codes"].items()):
-        percentage = (count / total_requests * 100) if total_requests > 0 else 0
-        report += f"  {code}: {count} ({percentage:.2f}%)\n"
-
-    # Add errors (limit to first 10)
-    if metrics["errors"]:
-        report += "\nERRORS (first 10):\n"
-        for err in metrics["errors"][:10]:
-            report += f"  - {err}\n"
-
-        if len(metrics["errors"]) > 10:
-            report += f"  ... and {len(metrics['errors']) - 10} more errors\n"
-
-    report += "\n" + "=" * 80
-
-    return report
-
-
 # === Run Load Test ===
 async def run_load_test():
     metrics["test_start_time"] = datetime.datetime.now()
@@ -589,7 +452,7 @@ async def run_load_test():
             print(f"  ... and {len(metrics['errors']) - 5} more errors")
 
     # === Enhanced Latency Report ===
-    latency_report = generate_latency_report()
+    latency_report = generate_latency_report(metrics)
     print(latency_report)
 
     # Save text and HTML reports
@@ -600,7 +463,7 @@ async def run_load_test():
             f.write(latency_report)
         print(f"\nLatency report saved to {text_filename}")
 
-        percentiles = calculate_latency_percentiles()
+        percentiles = calculate_latency_percentiles(metrics)
         html_content = generate_html_report(metrics, percentiles)
         html_filename = f"load_test_latency_{timestamp}.html"
         with open(html_filename, "w") as f:

--- a/performance/api/report_utils.py
+++ b/performance/api/report_utils.py
@@ -1,4 +1,5 @@
 import html
+import statistics
 from typing import Dict, Any
 
 
@@ -83,3 +84,114 @@ def generate_html_report(metrics: Dict[str, Any], percentiles: Dict[str, Any]) -
 
     html_parts.append("</body></html>")
     return "\n".join(html_parts)
+
+
+def calculate_latency_percentiles(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Calculate overall and per-endpoint latency percentiles."""
+    all_response_times = []
+    for data in metrics.get("endpoints", {}).values():
+        all_response_times.extend(data.get("response_times", []))
+
+    if not all_response_times:
+        return {}
+
+    all_response_times.sort()
+    total_count = len(all_response_times)
+    percentiles = {
+        "median": statistics.median(all_response_times),
+        "p90": all_response_times[int(total_count * 0.9)] if total_count > 1 else all_response_times[-1],
+        "p95": all_response_times[int(total_count * 0.95)] if total_count > 1 else all_response_times[-1],
+        "p99": all_response_times[int(total_count * 0.99)] if total_count > 1 else all_response_times[-1],
+    }
+
+    endpoint_percentiles = {}
+    for key, data in metrics.get("endpoints", {}).items():
+        times = data.get("response_times", [])
+        if times:
+            times.sort()
+            count = len(times)
+            endpoint_percentiles[key] = {
+                "median": statistics.median(times),
+                "p90": times[int(count * 0.9)] if count > 1 else times[-1],
+                "p95": times[int(count * 0.95)] if count > 1 else times[-1],
+                "p99": times[int(count * 0.99)] if count > 1 else times[-1],
+            }
+
+    return {"overall": percentiles, "endpoints": endpoint_percentiles}
+
+
+def generate_latency_report(metrics: Dict[str, Any]) -> str:
+    """Create a formatted text report of latency metrics."""
+    percentiles = calculate_latency_percentiles(metrics)
+    total_requests = metrics.get("success_count", 0) + metrics.get("failure_count", 0)
+    report = "\n" + "=" * 80 + "\n"
+    report += "                       DETAILED LATENCY METRICS\n"
+    report += "=" * 80 + "\n\n"
+
+    report += "TEST SUMMARY:\n"
+    start = metrics.get("test_start_time")
+    end = metrics.get("test_end_time")
+    report += f"  Start time: {start}\n"
+    report += f"  End time: {end}\n"
+    report += f"  Duration: {metrics.get('test_duration_seconds', 0):.2f} seconds\n"
+    report += f"  Total requests: {total_requests}\n"
+    if total_requests:
+        success = metrics.get("success_count", 0)
+        report += f"  Success rate: {success}/{total_requests} ({success/total_requests*100:.2f}%)\n"
+        report += f"  Requests per second: {total_requests/metrics.get('test_duration_seconds',1):.2f}\n"
+    else:
+        report += "  Success rate: 0/0 (0.00%)\n  Requests per second: 0.00\n"
+
+    report += "\nPHASE TIMING:\n"
+    for phase, duration in metrics.get("operation_phase_times", {}).items():
+        report += f"  {phase.replace('_',' ').title()}: {duration:.2f}ms\n"
+
+    report += "\nLATENCY DISTRIBUTION:\n"
+    total_latency = sum(metrics.get("latency_distribution", {}).values())
+    for rng, count in metrics.get("latency_distribution", {}).items():
+        pct = (count / total_latency * 100) if total_latency else 0
+        report += f"  {rng}: {count} requests ({pct:.2f}%)\n"
+
+    if "overall" in percentiles:
+        report += "\nOVERALL LATENCY PERCENTILES:\n"
+        report += f"  Median (P50): {percentiles['overall']['median']:.2f}ms\n"
+        report += f"  P90: {percentiles['overall']['p90']:.2f}ms\n"
+        report += f"  P95: {percentiles['overall']['p95']:.2f}ms\n"
+        report += f"  P99: {percentiles['overall']['p99']:.2f}ms\n"
+
+    endpoint_avg_times = []
+    for key, data in metrics.get("endpoints", {}).items():
+        if data.get("count", 0) > 0:
+            avg_time = data["total_time"] / data["count"]
+            endpoint_avg_times.append((key, avg_time, data))
+
+    if endpoint_avg_times:
+        endpoint_avg_times.sort(key=lambda x: x[1], reverse=True)
+        report += "\nTOP 5 SLOWEST ENDPOINTS:\n"
+        for key, avg_time, data in endpoint_avg_times[:5]:
+            report += f"  {key}:\n"
+            report += f"    Count: {data['count']}\n"
+            report += f"    Avg time: {avg_time:.2f}ms\n"
+            report += f"    Min time: {data['min']:.2f}ms\n"
+            report += f"    Max time: {data['max']:.2f}ms\n"
+            if key in percentiles.get("endpoints", {}):
+                ep = percentiles["endpoints"][key]
+                report += f"    Median (P50): {ep['median']:.2f}ms\n"
+                report += f"    P90: {ep['p90']:.2f}ms\n"
+                report += f"    P95: {ep['p95']:.2f}ms\n"
+                report += f"    P99: {ep['p99']:.2f}ms\n"
+
+    report += "\nSTATUS CODE DISTRIBUTION:\n"
+    for code, count in sorted(metrics.get("status_codes", {}).items()):
+        pct = (count / total_requests * 100) if total_requests else 0
+        report += f"  {code}: {count} ({pct:.2f}%)\n"
+
+    if metrics.get("errors"):
+        report += "\nERRORS (first 10):\n"
+        for err in metrics["errors"][:10]:
+            report += f"  - {err}\n"
+        if len(metrics["errors"]) > 10:
+            report += f"  ... and {len(metrics['errors'])-10} more errors\n"
+
+    report += "\n" + "=" * 80
+    return report

--- a/performance/api/report_utils.py
+++ b/performance/api/report_utils.py
@@ -1,0 +1,85 @@
+import html
+from typing import Dict, Any
+
+
+def generate_html_report(metrics: Dict[str, Any], percentiles: Dict[str, Any]) -> str:
+    """Return a simple HTML representation of the latency report."""
+    total_requests = metrics.get("success_count", 0) + metrics.get("failure_count", 0)
+    html_parts = [
+        "<html><head><meta charset='utf-8'><title>Load Test Report</title></head><body>",
+        "<h1>Detailed Latency Metrics</h1>",
+        "<h2>Test Summary</h2>",
+        "<ul>"
+    ]
+    html_parts.append(f"<li>Start time: {metrics.get('test_start_time')}</li>")
+    html_parts.append(f"<li>End time: {metrics.get('test_end_time')}</li>")
+    html_parts.append(f"<li>Duration: {metrics.get('test_duration_seconds', 0):.2f} seconds</li>")
+    html_parts.append(f"<li>Total requests: {total_requests}</li>")
+    success_rate = (metrics.get('success_count', 0) / total_requests * 100) if total_requests else 0
+    html_parts.append(f"<li>Success rate: {metrics.get('success_count', 0)}/{total_requests} ({success_rate:.2f}%)</li>")
+    if metrics.get('test_duration_seconds', 0) > 0:
+        rps = total_requests / metrics['test_duration_seconds']
+        html_parts.append(f"<li>Requests per second: {rps:.2f}</li>")
+    html_parts.append("</ul>")
+
+    # Phase timing
+    html_parts.append("<h2>Phase Timing</h2><ul>")
+    for phase, duration in metrics.get('operation_phase_times', {}).items():
+        html_parts.append(f"<li>{phase.replace('_',' ').title()}: {duration:.2f}ms</li>")
+    html_parts.append("</ul>")
+
+    # Latency distribution
+    html_parts.append("<h2>Latency Distribution</h2>")
+    html_parts.append("<table><thead><tr><th>Range</th><th>Count</th><th>Percentage</th></tr></thead><tbody>")
+    total_latency = sum(metrics.get('latency_distribution', {}).values())
+    for rng, count in metrics.get('latency_distribution', {}).items():
+        pct = (count / total_latency * 100) if total_latency else 0
+        html_parts.append(f"<tr><td>{rng}</td><td>{count}</td><td>{pct:.2f}%</td></tr>")
+    html_parts.append("</tbody></table>")
+
+    # Overall percentiles
+    if 'overall' in percentiles:
+        html_parts.append("<h2>Overall Latency Percentiles</h2><ul>")
+        html_parts.append(f"<li>Median (P50): {percentiles['overall']['median']:.2f}ms</li>")
+        html_parts.append(f"<li>P90: {percentiles['overall']['p90']:.2f}ms</li>")
+        html_parts.append(f"<li>P95: {percentiles['overall']['p95']:.2f}ms</li>")
+        html_parts.append(f"<li>P99: {percentiles['overall']['p99']:.2f}ms</li>")
+        html_parts.append("</ul>")
+
+    # Endpoint metrics - top 5 slowest
+    endpoint_avg_times = []
+    for key, data in metrics.get('endpoints', {}).items():
+        if data.get('count', 0) > 0:
+            avg = data['total_time'] / data['count']
+            endpoint_avg_times.append((key, avg, data))
+    endpoint_avg_times.sort(key=lambda x: x[1], reverse=True)
+    top = endpoint_avg_times[:5]
+
+    if top:
+        html_parts.append("<h2>Endpoint Performance (Top 5 slowest)</h2>")
+        html_parts.append("<table><thead><tr><th>Endpoint</th><th>Count</th><th>Avg</th><th>Min</th><th>Max</th></tr></thead><tbody>")
+        for key, avg, data in top:
+            html_parts.append(
+                f"<tr><td>{html.escape(key)}</td><td>{data['count']}</td><td>{avg:.2f}ms</td><td>{data['min']:.2f}ms</td><td>{data['max']:.2f}ms</td></tr>"
+            )
+        html_parts.append("</tbody></table>")
+
+    # Status code distribution
+    html_parts.append("<h2>Status Codes</h2>")
+    html_parts.append("<table><thead><tr><th>Status</th><th>Count</th><th>Percentage</th></tr></thead><tbody>")
+    for code, count in sorted(metrics.get('status_codes', {}).items()):
+        pct = (count / total_requests * 100) if total_requests else 0
+        html_parts.append(f"<tr><td>{code}</td><td>{count}</td><td>{pct:.2f}%</td></tr>")
+    html_parts.append("</tbody></table>")
+
+    # Errors if any
+    if metrics.get('errors'):
+        html_parts.append("<h2>Errors (first 10)</h2><ul>")
+        for err in metrics['errors'][:10]:
+            html_parts.append(f"<li>{html.escape(err)}</li>")
+        if len(metrics['errors']) > 10:
+            html_parts.append(f"<li>... and {len(metrics['errors'])-10} more errors</li>")
+        html_parts.append("</ul>")
+
+    html_parts.append("</body></html>")
+    return "\n".join(html_parts)


### PR DESCRIPTION
## Summary
- generate HTML summary for API load test metrics
- publish HTML artifacts in workflow

## Testing
- `python -m py_compile performance/api/load.py performance/api/report_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684aa19d25c083248ed867baee78a4eb